### PR TITLE
If you click outside an edit form, it goes away

### DIFF
--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
+import useClickOutside from "../../hooks/useClickOutside";
 
 export const PostForm = ({
   Box,
@@ -73,12 +74,21 @@ export const PostForm = ({
     </fieldset>
   );
 
+  const clickRef = useRef();
+  useClickOutside(clickRef, () => {
+    renderCallback(post.id ? post.id : undefined);
+  });
+
+  /* test for NO postObj (indicates editing rather than creating) and
+      NOT our minimode state -- if that is the case, render minimode
+    OTHERWISE render the form with the clickRef used to close the form
+  */
   return !displayForm && !postObj ? (
     <Box isForm={true} boxStyle={boxStyle}>
       <button onClick={() => setDisplayForm(true)}>Add a {postType}</button>
     </Box>
   ) : (
-    <Box isForm={true} boxStyle={boxStyle}>
+    <Box isForm={true} boxStyle={boxStyle} ref={clickRef}>
       <form>
         {/* TextFields must be called like this to avoid losing focus on rerender */}
         {TextField({

--- a/src/components/posts/PostForm.js
+++ b/src/components/posts/PostForm.js
@@ -74,6 +74,7 @@ export const PostForm = ({
     </fieldset>
   );
 
+  // implement the custom hook useClickOutside to tell the postlist we're done editing
   const clickRef = useRef();
   useClickOutside(clickRef, () => {
     renderCallback(post.id ? post.id : undefined);

--- a/src/components/posts/PostsList.js
+++ b/src/components/posts/PostsList.js
@@ -44,6 +44,7 @@ export const PostsList = ({
     [...editingPostIds].indexOf(p.id) >= 0 && isCurrentUser ? (
       <PostForm
         postType={postType}
+        key={p.id}
         postObj={p}
         Box={Box}
         boxStyle={boxStyle}
@@ -96,9 +97,9 @@ const Image = styled.img`
   padding-bottom: 1rem;
 `;
 
-const Heading = styled.h2`
-  text-align: center;
-`;
+// const Heading = styled.h2`
+//   text-align: center;
+// `;
 
 const SubHeading = styled.h4`
   text-align: center;

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+const useClickOutside = (ref, callback) => {
+  const handleClick = (e) => {
+    if (ref.current && !ref.current.contains(e.target)) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleClick);
+    return () => {
+      document.removeEventListener("click", handleClick);
+    };
+  });
+};
+
+export default useClickOutside;


### PR DESCRIPTION
- Added custom hook `useClickOutside`
- Implemented new custom hook with `renderCallback` on each PostForm created by editing an existing post